### PR TITLE
feat(skills): add pr-feedback-triage skill

### DIFF
--- a/docs/LOOKUP/SKILLS.md
+++ b/docs/LOOKUP/SKILLS.md
@@ -55,6 +55,9 @@ Use when completing tasks, implementing major features, or before merging to ver
 ### receiving-code-review
 Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
 
+### pr-feedback-triage
+Audit already-merged PRs for review feedback that was never acted on - verifies each concern against origin/main, then reconciles survivors with Linear (files new tickets, enhances matched ones, merges duplicates). Requires the Linear MCP server.
+
 ### validating-review-feedback
 Validate code review feedback against implementation plan to prevent scope creep and derailment
 

--- a/plugin/skills/pr-feedback-triage/SKILL.md
+++ b/plugin/skills/pr-feedback-triage/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: pr-feedback-triage
+description: Audit already-merged PRs for code review feedback that was never acted on: collect the comments, verify each concern against origin/main, then reconcile the survivors with Linear — filing new tickets, enhancing matched ones, merging duplicates. Use this whenever someone suspects review feedback got dropped, steamrolled, or forgotten, and asks things like "did we ever fix what X flagged", "did we ever action those comments", "which of those open threads are still real problems on main", "what review feedback fell through the cracks", "audit last sprint's merged PRs", or "turn leftover review comments into tickets". It applies to a single named PR just as much as to a whole time window, to any base branch, and whether or not the user mentions Linear or a tracker at all — wanting to know which concerns from a merged PR are still live is reason enough. Not for reviewing an unmerged diff yourself, listing threads on still-open PRs, making the changes a reviewer asked for on your own open PR, or tracker housekeeping unrelated to review comments.
+when_to_use: when review feedback on merged PRs may have been dropped, when auditing whether reviewer concerns were actually fixed, when turning surviving review comments into tracker tickets
+version: 1.0.0
+---
+
+# PR feedback triage
+
+Review comments get written, the PR merges anyway, and the concern evaporates. This
+skill finds those, checks which are genuinely still live, and makes sure each one has
+exactly one Linear ticket.
+
+The failure mode to guard against is a plausible-looking ticket for a problem that was
+fixed three PRs ago. That wastes a human's time and erodes trust in the whole exercise
+faster than missing an item does. **Verify before you file.** When you cannot verify,
+say so in the plan rather than quietly assuming.
+
+## Requirements
+
+- `gh` CLI, authenticated. The collector script uses the GitHub GraphQL API.
+- **The Linear MCP server must be connected.** Phases 1–3 work without it; Phase 4
+  cannot. Its tools are usually deferred — load them with `ToolSearch` before Phase 4.
+- Python 3.9+ for the collector.
+
+## Workflow
+
+Five phases: collect → triage → verify → reconcile → apply. Only the last one writes
+anything. Track them with your todo tool; a stalled run should be obvious.
+
+---
+
+## Phase 1 — Collect
+
+Resolve the window and the repo first. If the user said "the last sprint" or "since the
+release", turn that into a date and **tell them what you resolved it to** — a silently
+wrong window silently omits PRs.
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}skills/pr-feedback-triage/scripts/fetch_pr_feedback.py \
+  --since 14d -o feedback.json
+```
+
+`--since` takes a span (`14d`, `3w`, `2m`) or an ISO date. Add `--until` for a closed
+window, `--repo owner/name` to override the current repo, `--include-bots` if the user
+explicitly wants Copilot's or CodeRabbit's comments.
+
+**Sweep every base branch. Do not reach for `--base`.** When a user says "the PRs we
+merged into main", they mean the work that reached main — not the subset whose merge
+commit happened to target it. Repos that stage a release on a long-lived branch merge
+their richest, most-reviewed PRs into *that* branch, and it lands on main later as one
+squashed merge. Filtering by base drops exactly the feedback worth finding: on a real
+run, `--base main` collapsed thirteen feedback-bearing PRs down to one, and the survivor
+was the release commit. If you have a genuine reason to filter, run unfiltered first and
+tell the user what the filter would have excluded.
+
+Each item carries a stable id (`PR1234-T4`), an author, a permalink, and — for inline
+threads — `path` and `line`. Use those ids everywhere downstream, so a plan line, a
+ticket callout, and a verification note all refer to the same thing.
+
+Two fields are traps:
+
+- `severity_hint` is a regex guess from the comment's first line. Many teams don't
+  prefix at all, so a `null` hint means nothing, and a comment prefixed `nit:` can still
+  describe a real bug. Read the body; the hint only breaks ties.
+- `is_resolved` and `is_outdated` are recorded but are **not** evidence. Plenty of teams
+  never resolve threads, so a PR can merge with every thread still open — including the
+  ones marked blocking. Judge from the code, never from the checkbox.
+
+---
+
+## Phase 2 — Triage
+
+Keep an item if a reasonable engineer would want it tracked: **blockers, bugs, design
+issues, documentation issues.** Drop praise, style bikeshedding, questions already
+answered in a reply, and anything whose fix is smaller than the ticket describing it.
+
+A `review_body` item is often a *summary review* bundling many distinct findings in
+prose — "Second pass: 9 items not covered by the existing threads". Split it. Each
+finding becomes its own item, id-suffixed (`PR1234-R2#3`), because they will get
+different verification results and probably different tickets.
+
+For each kept item record: a one-line title, a category (blocker / bug / design / docs),
+the concrete claim being made, and where it says the problem lives.
+
+When you're unsure whether something is minor, ask what happens if it's never fixed. If
+the answer is "nothing", drop it.
+
+---
+
+## Phase 3 — Verify against origin/main
+
+`git fetch origin` first — a stale ref invalidates the entire run.
+
+An item survives only if the concern **still holds on `origin/main` today**. Read the
+cited file there (search for the construct by name; code moves), and check
+`git log origin/main -- <path>` since the PR's merge commit for a later fix. Note that a
+long-lived PR often fixes its own review comments on later commits *before* merging, so
+"no follow-up commit touched this file" does not mean "never fixed".
+
+**Where the comment implies a check, run it.** This is what separates a trustworthy
+verdict from a confident guess, and it is the step most easily skipped. "This test runs
+in no CI job" → grep the workflow files. "The allowlist references a type that doesn't
+exist" → grep for the type. "This task is broken" → run the task. Repo-native checks are
+cheap and decisive. Prefer a command whose output you can quote over a paragraph of
+reasoning about what the code probably does.
+
+Verification is per-item and independent, so **fan it out across subagents** when there
+are more than a handful. Give each the item, the repo path, and instructions to return a
+verdict plus its evidence. Twenty items verified serially is a slow, context-hungry run
+for no benefit.
+
+Assign one of three verdicts and carry the evidence forward — the evidence is what makes
+the plan reviewable:
+
+- `still-live` — reproduced the concern on `origin/main`.
+- `addressed` — found the fix. Drop it, but name the commit in the summary so the user
+  can spot a wrong call. A reply saying "fixed" or "will do" is not a commit.
+- `unverifiable` — you genuinely cannot tell: it needs a database, credentials, or
+  runtime behaviour you can't exercise. **Do not drop these and do not quietly file them
+  as if confirmed.** Surface them as their own group, and if one is filed anyway, say so
+  in the ticket itself. A ticket that overstates its own confidence is worse than no
+  ticket, because the next person trusts it.
+
+---
+
+## Phase 4 — Reconcile with Linear
+
+### Items are not tickets
+
+Group first, then search. Several findings that share a **root cause** belong in one
+ticket, because they will be fixed in one sitting by one person: four separate defects
+in the same CI script are one "harden this script" ticket, not four. Findings that share
+only a *theme* ("docs are stale") but live in unrelated files are still one ticket if a
+single pass fixes them all, and separate tickets if not.
+
+The test is whether a reader would open one PR or several. Err toward fewer, larger
+tickets — a board with forty single-comment tickets is a board nobody triages. But keep
+a genuinely load-bearing bug (a CI gate that fails open, a query that errors) as its own
+ticket even when its neighbours are cleanup, or it will be invisible inside a checklist.
+
+When many findings come from one PR that already has a Linear ticket, consider filing
+them as **children of that ticket** rather than as top-level siblings. It keeps the board
+tidy and gives the parent the content its author never wrote.
+
+### Search before you file
+
+Search Linear for each surviving group before concluding it needs a new ticket.
+Constrain by `updatedAt` to the same window plus a margin — a ticket filed in response
+to this feedback can't predate the PR — and search on the *substance*, not the
+comment's wording. Try the symbol name, the file path, and the failure mode separately;
+one query rarely finds it.
+
+Then, per group:
+
+**Several plausible tickets.** They may be duplicates of each other. Pick the survivor —
+oldest, most complete, or the one with real discussion on it — and fold the others in.
+Read the duplicates fully before merging: two tickets sharing a keyword often describe
+genuinely different problems, and merging those destroys information. On the loser, set
+status to the workspace's existing `Duplicate` state and comment a link to the survivor.
+Never delete.
+
+**Exactly one plausible ticket.** Enhance rather than duplicate. Add what the feedback
+contributes that the ticket lacks — the file and line, the reviewer's reasoning, the
+verification evidence. Correct metadata that's now wrong. If the ticket already says
+everything, leave it alone and record it as `no-change`; a no-op edit is noise on
+someone's board.
+
+**No ticket.** File one. Title as an assertion of the problem, not a restatement of the
+comment. Body: what's wrong, where, why it matters, and the reviewer's own words quoted
+with a link.
+
+Two constraints on all Linear writes:
+
+- **Use existing metadata only.** Never create a project, label, status, or team. Read
+  what exists (`list_issue_labels`, `list_issue_statuses`, `list_projects`) and pick from
+  it. If nothing fits, use nothing and say so in the plan.
+- **Infer the team and project from the tickets you matched.** File alongside the work
+  the feedback belongs to. If no ticket matched and the target is genuinely ambiguous,
+  ask the user rather than guessing at their board's conventions.
+
+---
+
+## Phase 5 — Plan, confirm, apply
+
+Present the plan and **stop**. Linear is other people's shared workspace; a bad dedup
+call is visible to the whole team and tedious to unpick. Do not write until the user
+approves, unless they said something like "just do it".
+
+The plan is a table the user can scan, grouped by action:
+
+```
+CREATE  (3)
+  PR1234-T1  Blocking   integration test suite runs in no CI job
+             → Platform · no label matched
+  ...
+UPDATE  (2)
+  PR1234-T6  ENG-455    add file:line + verification evidence
+DUPLICATE (1)
+  ENG-461 → ENG-455     both describe the same stale allowlist rows
+NO CHANGE (4)   already fully captured
+UNVERIFIABLE (2)   needs a database to confirm — your call
+DROPPED (31)    addressed on main (12) · minor (19)
+```
+
+Show the counts even for dropped items. A user glancing at "dropped 31" and thinking
+"that's too many" is the cheapest bug-catch in this whole workflow.
+
+On approval, apply the writes. If one fails, keep going and report the failures at the
+end — a half-applied plan the user knows about beats an aborted one they don't.
+
+---
+
+## The callout
+
+Every ticket this skill creates or modifies gets this at the **top of the description**,
+above the existing content:
+
+```markdown
+> [!note]
+> Created by Claude as a result of triaging **<owner/repo>** for unaddressed PR feedback,
+> triggered by **<user>**.
+>
+> Source feedback:
+> - [PR #1234 — `ci/lint.sh`: allowlist rows for a type that no longer exists](<permalink>)
+> - [PR #1234 — review summary, item 3](<permalink>)
+```
+
+`<owner/repo>` comes from the fetch output's `repo`. `<user>` is the git identity
+(`git config user.name`) — the person who ran the triage, not the reviewer who wrote the
+comment.
+
+Link every source item that fed the ticket, using the item's permalink from the fetch
+output. When you update a ticket that already carries a callout from a previous run,
+extend its source list rather than stacking a second callout block.
+
+## Reference
+
+`references/linear-conventions.md` — the exact MCP calls for each write, callout
+placement when a description already has one, and how to search Linear effectively.
+Read it before Phase 4.

--- a/plugin/skills/pr-feedback-triage/references/linear-conventions.md
+++ b/plugin/skills/pr-feedback-triage/references/linear-conventions.md
@@ -1,0 +1,118 @@
+# Linear conventions for PR feedback triage
+
+Read this before Phase 4. It covers searching, the exact write calls, and callout
+placement. The Linear MCP tools are deferred — load them with `ToolSearch` first:
+
+```
+select:mcp__claude_ai_Linear__list_issues,mcp__claude_ai_Linear__get_issue,mcp__claude_ai_Linear__save_issue,mcp__claude_ai_Linear__save_comment,mcp__claude_ai_Linear__list_issue_labels,mcp__claude_ai_Linear__list_issue_statuses,mcp__claude_ai_Linear__list_teams,mcp__claude_ai_Linear__list_projects
+```
+
+Tool names vary with how the Linear MCP server is registered. If that selector returns
+nothing, search by keyword (`ToolSearch "+linear issue"`) rather than assuming the
+server is absent.
+
+## Searching for an existing ticket
+
+`list_issues` matches `query` against title and description. It is a *substring-ish*
+match, not semantic — so one query per concept, not one query per item.
+
+Search on the substance of the problem, from three angles. For a finding like "twelve
+allowlist rows referencing a type that no longer exists, in `ci/lint.sh`":
+
+| Angle | Example query |
+|---|---|
+| Symbol | the removed type's name |
+| Path | `lint` |
+| Failure mode | `allowlist` |
+
+Constrain with `updatedAt` to the triage window plus a generous margin (a month), and
+`includeArchived: true` — a closed-then-archived ticket still means the work was tracked.
+Widen if you get nothing; a false "no ticket exists" produces a duplicate, which is the
+most annoying outcome for the team.
+
+Do not filter by team on the first pass. Feedback about a repo often has tickets on more
+than one team's board, and you need to see that to infer where the new one belongs.
+
+Read candidates with `get_issue` before deciding. A title match is not a content match.
+
+## Inferring the target team and project
+
+Take the team and project from the tickets you matched for that item, or for its
+neighbours in the same PR. Concretely: if `ENG-455` covers a sibling finding from the
+same PR and sits in the Platform team under project "Q3 Hardening", file there too.
+
+If nothing matched anywhere, ask the user. Do not default to the first team in
+`list_teams`.
+
+## Writes
+
+All issue writes go through `save_issue` — it creates when `id` is absent and updates
+when present.
+
+**Create.** Pass `team`, `title`, `description`, and `project` only if you inferred one.
+Set `labels` only from names returned by `list_issue_labels`. Omit `priority` unless the
+feedback states urgency; an invented priority is noise.
+
+```
+save_issue(team: "<inferred>", title: "<assertion of the problem>",
+           description: "<callout>\n\n<body>", project: "<inferred, optional>",
+           parentId: "<the PR's own ticket, when filing its findings as children>")
+```
+
+`parentId` accepts an issue identifier like `ENG-455`. Sub-issues survive the parent
+closing, so parenting under an in-flight ticket is safe.
+
+**Update.** Fetch the current description with `get_issue`, then write the full new
+description back — `save_issue` replaces it wholesale, so read-modify-write or you will
+destroy the existing content. Pass **only** `id` and `description`: `labels` replaces the
+entire label set, so naming it on an update silently strips any label you didn't list.
+Omitting a field leaves it alone, which is what you want for assignee, milestone, parent,
+and priority on someone else's ticket.
+
+**Mark a duplicate.** Two calls. Set the status to the workspace's existing duplicate
+state (look it up in `list_issue_statuses` — it is commonly named `Duplicate`), and leave
+a comment pointing at the survivor.
+
+```
+save_issue(id: "<loser>", state: "Duplicate")
+save_comment(issueId: "<loser>", body: "Merged into <survivor identifier> during PR feedback triage. ...")
+```
+
+Never delete an issue and never rewrite a human's description content — you may only
+prepend the callout and append new sections.
+
+## Never create metadata
+
+No new projects, labels, statuses, teams, or initiatives. If nothing in
+`list_issue_labels` fits, apply no label and note it in the plan as `no label matched`.
+A wrong label is worse than none: it pollutes someone's saved view.
+
+## Callout placement
+
+The callout goes at the very top of the description, before all existing content.
+
+**Ticket has no callout** — prepend it, then a blank line, then the original description
+unchanged.
+
+**Ticket already has a callout from a previous run** — do not stack a second one. Extend
+the existing `Source feedback:` list with any new item links, deduplicating by URL.
+Leave the rest of the block alone.
+
+**Ticket is being enhanced with new information** — the callout summarises provenance,
+not the finding. Put the actual technical content in the body below, under a heading
+like `## Additional detail from PR review`, quoting the reviewer and linking the
+permalink.
+
+Format:
+
+```markdown
+> [!note]
+> Created by Claude as a result of triaging **owner/repo** for unaddressed PR feedback,
+> triggered by **Jane Doe**.
+>
+> Source feedback:
+> - [PR #1234 — `ci/lint.sh`: allowlist rows for a type that no longer exists](https://github.com/...#discussion_r...)
+```
+
+Link text should say what the feedback was, so the list is readable without clicking.
+`[PR #1234 — comment](url)` tells a reader nothing.

--- a/plugin/skills/pr-feedback-triage/scripts/fetch_pr_feedback.py
+++ b/plugin/skills/pr-feedback-triage/scripts/fetch_pr_feedback.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Collect review feedback from merged PRs in a time window.
+
+Emits normalised JSON on stdout so the triaging agent never has to hand-roll
+GraphQL. Every feedback item gets a stable id (e.g. PR1234-T4) that downstream
+steps use to refer to it in plans, tickets, and callouts.
+
+Usage:
+    fetch_pr_feedback.py --since 14d
+    fetch_pr_feedback.py --since 2026-06-01 --until 2026-07-01
+    fetch_pr_feedback.py --since 30d --repo owner/name --include-bots
+
+Requires the `gh` CLI, authenticated.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+# Authors whose comments are almost never actionable review feedback. Matched
+# exactly against the login, never as a substring -- a human login can share a
+# prefix with a bot's (e.g. a user named `coder...` vs `coderabbitai`).
+DEFAULT_BOT_LOGINS = {
+    "copilot-pull-request-reviewer",
+    "copilot",
+    "github-actions",
+    "dependabot",
+    "changeset-bot",
+    "coderabbitai",
+    "sonarcloud",
+    "codecov",
+    "vercel",
+    "netlify",
+}
+
+# Many teams prefix review comments with a severity. Capturing it here is a
+# hint for the triager, not a verdict: an unprefixed comment can still be a
+# blocker, and a "nit" prefix on a real bug is still a real bug.
+SEVERITY_PATTERNS = [
+    ("blocker", r"^\W*(blocking|blocker|must[- ]fix|required|p0)\b"),
+    ("should-fix", r"^\W*(should[- ]fix|important|p1)\b"),
+    ("minor", r"^\W*(nit|nitpick|minor|style|optional|suggestion|praise|typo|p3)\b"),
+    ("question", r"^\W*(question|q:|curious)\b"),
+]
+
+PR_SEARCH = """
+query($q: String!, $after: String) {
+  search(query: $q, type: ISSUE, first: 50, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      ... on PullRequest {
+        number title url mergedAt baseRefName
+        author { login __typename }
+        mergeCommit { oid }
+      }
+    }
+  }
+}
+"""
+
+PR_DETAIL = """
+query($owner: String!, $name: String!, $number: Int!, $tAfter: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviews(first: 100) {
+        nodes {
+          author { login __typename }
+          state body url submittedAt
+        }
+      }
+      comments(first: 100) {
+        nodes { author { login __typename } body url createdAt }
+      }
+      reviewThreads(first: 100, after: $tAfter) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved isOutdated path line originalLine
+          comments(first: 50) {
+            nodes { author { login __typename } body url createdAt }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def gh_graphql(query, **variables):
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for key, value in variables.items():
+        if value is None:
+            continue
+        flag = "-F" if isinstance(value, int) else "-f"
+        cmd += [flag, f"{key}={value}"]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.exit(f"gh graphql failed:\n{proc.stderr.strip()}")
+    payload = json.loads(proc.stdout)
+    if "errors" in payload:
+        sys.exit("graphql errors: " + json.dumps(payload["errors"], indent=2))
+    return payload["data"]
+
+
+def resolve_repo(explicit):
+    if explicit:
+        return explicit
+    proc = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        sys.exit("could not determine repo; pass --repo owner/name")
+    return proc.stdout.strip()
+
+
+def parse_when(value):
+    """Accept an ISO date or a relative span like 14d / 3w / 6m."""
+    if value is None:
+        return None
+    m = re.fullmatch(r"(\d+)\s*([dwmy])", value.strip(), re.I)
+    if m:
+        n, unit = int(m.group(1)), m.group(2).lower()
+        days = {"d": 1, "w": 7, "m": 30, "y": 365}[unit] * n
+        return (datetime.now(timezone.utc) - timedelta(days=days)).date().isoformat()
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).date().isoformat()
+    except ValueError:
+        sys.exit(f"could not parse date/span: {value!r} (try 14d or 2026-06-01)")
+
+
+def severity_hint(body):
+    first_line = (body or "").strip().splitlines()[0] if (body or "").strip() else ""
+    probe = first_line.lower()
+    for label, pattern in SEVERITY_PATTERNS:
+        if re.search(pattern, probe, re.I):
+            return label
+    return None
+
+
+def is_bot(author, include_bots):
+    if include_bots:
+        return False
+    if not author:
+        return True
+    if author.get("__typename") == "Bot":
+        return True
+    return author.get("login", "").lower() in DEFAULT_BOT_LOGINS
+
+
+def author_login(author):
+    return (author or {}).get("login", "ghost")
+
+
+def collect_pr(owner, name, pr, include_bots):
+    threads, cursor = [], None
+    reviews = comments = None
+    while True:
+        data = gh_graphql(
+            PR_DETAIL, owner=owner, name=name, number=pr["number"], tAfter=cursor
+        )["repository"]["pullRequest"]
+        if reviews is None:
+            reviews, comments = data["reviews"]["nodes"], data["comments"]["nodes"]
+        threads += data["reviewThreads"]["nodes"]
+        page = data["reviewThreads"]["pageInfo"]
+        if not page["hasNextPage"]:
+            break
+        cursor = page["endCursor"]
+
+    items = []
+
+    for idx, thread in enumerate(threads, 1):
+        nodes = thread["comments"]["nodes"]
+        if not nodes:
+            continue
+        head = nodes[0]
+        if is_bot(head["author"], include_bots):
+            continue
+        items.append({
+            "id": f"PR{pr['number']}-T{idx}",
+            "kind": "review_thread",
+            "author": author_login(head["author"]),
+            "url": head["url"],
+            "path": thread["path"],
+            "line": thread["line"] or thread["originalLine"],
+            # Recorded for context only. Do not treat as evidence the concern
+            # was addressed -- many teams never resolve threads at all.
+            "is_resolved": thread["isResolved"],
+            "is_outdated": thread["isOutdated"],
+            "severity_hint": severity_hint(head["body"]),
+            "body": head["body"],
+            "replies": [
+                {"author": author_login(c["author"]), "body": c["body"]}
+                for c in nodes[1:]
+                if not is_bot(c["author"], include_bots)
+            ],
+        })
+
+    for idx, review in enumerate(reviews, 1):
+        if is_bot(review["author"], include_bots) or not (review["body"] or "").strip():
+            continue
+        items.append({
+            "id": f"PR{pr['number']}-R{idx}",
+            # A summary review body often bundles several distinct findings.
+            # The triager is expected to split it into separate items.
+            "kind": "review_body",
+            "author": author_login(review["author"]),
+            "url": review["url"],
+            "path": None,
+            "line": None,
+            "state": review["state"],
+            "severity_hint": severity_hint(review["body"]),
+            "body": review["body"],
+            "replies": [],
+        })
+
+    for idx, comment in enumerate(comments, 1):
+        if is_bot(comment["author"], include_bots) or not (comment["body"] or "").strip():
+            continue
+        items.append({
+            "id": f"PR{pr['number']}-C{idx}",
+            "kind": "pr_comment",
+            "author": author_login(comment["author"]),
+            "url": comment["url"],
+            "path": None,
+            "line": None,
+            "severity_hint": severity_hint(comment["body"]),
+            "body": comment["body"],
+            "replies": [],
+        })
+
+    return {
+        "number": pr["number"],
+        "title": pr["title"],
+        "url": pr["url"],
+        "merged_at": pr["mergedAt"],
+        "base": pr["baseRefName"],
+        "merge_commit": (pr.get("mergeCommit") or {}).get("oid"),
+        "author": author_login(pr["author"]),
+        "items": items,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--since", required=True, help="ISO date or span (14d, 3w, 2m)")
+    ap.add_argument("--until", help="ISO date; defaults to now")
+    ap.add_argument("--repo", help="owner/name; defaults to the current repo")
+    ap.add_argument("--base", help="only PRs merged into this branch, e.g. main")
+    ap.add_argument("--include-bots", action="store_true")
+    ap.add_argument("-o", "--out", help="write JSON here instead of stdout")
+    args = ap.parse_args()
+
+    repo = resolve_repo(args.repo)
+    owner, name = repo.split("/", 1)
+    since, until = parse_when(args.since), parse_when(args.until)
+
+    merged = f"merged:>={since}" + (f" merged:<={until}" if until else "")
+    query = f"repo:{repo} is:pr is:merged {merged}"
+    if args.base:
+        query += f" base:{args.base}"
+
+    prs, cursor = [], None
+    while True:
+        page = gh_graphql(PR_SEARCH, q=query, after=cursor)["search"]
+        prs += [n for n in page["nodes"] if n]
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+
+    collected = [collect_pr(owner, name, pr, args.include_bots) for pr in prs]
+    collected = [pr for pr in collected if pr["items"]]
+    collected.sort(key=lambda p: p["number"])
+
+    result = {
+        "repo": repo,
+        "window": {"since": since, "until": until or "now"},
+        "prs_in_window": len(prs),
+        "prs_with_feedback": len(collected),
+        "total_items": sum(len(pr["items"]) for pr in collected),
+        "prs": collected,
+    }
+
+    text = json.dumps(result, indent=2)
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(text + "\n")
+        print(
+            f"{result['total_items']} feedback items from "
+            f"{result['prs_with_feedback']}/{result['prs_in_window']} merged PRs "
+            f"→ {args.out}",
+            file=sys.stderr,
+        )
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `pr-feedback-triage`: a skill that finds code review feedback which was written on a PR, never acted on, and quietly lost when the PR merged.

It works in five phases — **collect → triage → verify → reconcile → apply** — and only the last one writes anything:

1. **Collect** every review thread, summary-review body, and PR comment from merged PRs in a time window, via the bundled `scripts/fetch_pr_feedback.py` (GitHub GraphQL → normalised JSON with stable per-item ids).
2. **Triage** down to what a reasonable engineer would want tracked: blockers, bugs, design issues, docs issues. Praise and bikeshedding are dropped.
3. **Verify** each survivor against `origin/main` — because the expensive failure mode here is filing a confident ticket for a problem that was fixed three PRs ago.
4. **Reconcile** with Linear: group findings by root cause, search before filing, enhance a half-matching ticket rather than duplicating it, mark genuine duplicates `Duplicate` and link the survivor.
5. **Plan, confirm, apply.** It presents a plan and stops. Nothing is written to Linear without approval.

Every ticket it creates or modifies carries a provenance callout naming the repo and the person who ran the triage, with links to the specific source comment permalinks.

## Why

Review threads routinely merge unresolved. GitHub's `isResolved` flag is unreliable in practice — teams that don't use it will happily merge a PR with every thread open, blockers included — so "was this ever fixed?" can only be answered by reading the code on `origin/main`. Doing that by hand across a sprint's worth of PRs is tedious enough that nobody does it, and real blockers rot.

## Testing

Three realistic scenarios (full-window sweep, single-PR verification, dedup-before-filing), each run **with and without** the skill against a live repository, then graded against per-scenario assertions.

- Assertions: **24/24** with the skill, **21/24** baseline.
- Coverage the score didn't capture: the skill swept **13** feedback-bearing PRs where the baseline examined **8**, and split prose summary reviews into **24 distinct findings** where the baseline treated them as **19 threads**.
- **Zero Linear write calls** in any dry run — verified by grepping every agent transcript, parent and child.

Two bugs the evaluation caught and this version fixes: silently passing `--base main` (which collapsed 13 feedback-bearing PRs to 1, because feature work lands on a staging branch first), and filing one ticket per comment instead of grouping by root cause.

The skill has since been used for a real triage: 8 tickets filed, 2 enhanced, all with verified evidence.

## Notes for reviewers

- **Requires the Linear MCP server** to be connected. Phases 1–3 work without it; phase 4 does not. This is stated in the skill's Requirements section.
- The skill bundles an executable script, which is a first for `plugin/skills/`. It's referenced as `${CLAUDE_PLUGIN_ROOT}skills/pr-feedback-triage/scripts/fetch_pr_feedback.py`, matching the path convention the agents use. If the project would rather executables live in `plugin/scripts/`, happy to move it.
- All examples are generic (`PR1234`, `ENG-455`) — no internal ticket ids, PR numbers, team names, or reviewer handles.